### PR TITLE
Personal Data Fields being parsed ahead of exposing PDF aliases

### DIFF
--- a/gallagher/cc/core.py
+++ b/gallagher/cc/core.py
@@ -143,29 +143,6 @@ class Capabilities:
         features=FeaturesDetail(),
     )
 
-    # Personal Data Fields are defined per instance of the command centre
-    # Upon discover, the client core must fetch the PDF and cache it for
-    # use by various other endpoints such as Cardholers.
-    # 
-    # Note that the response returns a list of keys that don't conform to
-    # the snake_case naming convention, they contain spaces and when referenced
-    # by the other fields have an @ prefix in most instances
-    PERSONAL_DATA_FIELDS = None # When discovered this should at least be []
-
-    @classmethod
-    def pdf_field_names(cls):
-        """Returns a list of PDF names"""
-        return [pdf.name for pdf in cls.PERSONAL_DATA_FIELDS]
-    
-    @classmethod
-    def pdf_field_name_to_attribute_map(cls):
-        """Returns a dictionary of PDF names to attributes"""
-        return {
-            pdf.name: pdf.name.replace(' ', '_').lower()\
-                  for pdf in cls.PERSONAL_DATA_FIELDS
-        }
-
-
 class APIEndpoint:
     """Base class for all API objects
 
@@ -269,9 +246,6 @@ class APIEndpoint:
             # an instance of a pydantic object and all values are thus
             # copied not referenced.
             cls.__config__ = await cls.get_config()
-
-            from .cardholders import PdfDefinition
-            Capabilities.PERSONAL_DATA_FIELDS = await PdfDefinition.list()
 
 
     @classmethod

--- a/gallagher/dto/detail/cardholder.py
+++ b/gallagher/dto/detail/cardholder.py
@@ -1,5 +1,7 @@
 """ Cardholder Detail """
-from typing import Optional
+from typing import Optional, Any
+
+from pydantic import Extra, model_validator, ValidationError
 
 from ..utils import (
     AppBaseModel,
@@ -75,6 +77,19 @@ class CardholderDetail(
     # elevator_groups
     updates: PlaceholderRef
     # redactions
+
+    @model_validator(mode='before')
+    @classmethod
+    def validate_pdf(cls, data: Any) -> Any:
+
+        known_fields = { "@Company Name" }
+
+        for key in data:
+            if key not in known_fields:
+                print(key)
+
+        return data
+
 
     def get_pdf(self, PDFRef):
         """Get a parsed PDF field from the cardholder given the PDF Ref

--- a/gallagher/dto/summary/__init__.py
+++ b/gallagher/dto/summary/__init__.py
@@ -57,3 +57,7 @@ from .visitor import (
     VisitorManagementSummary,
     VisitorTypeSummary,
 )
+
+from .pdf import (
+    PdfSummary,
+)

--- a/gallagher/dto/summary/pdf.py
+++ b/gallagher/dto/summary/pdf.py
@@ -19,4 +19,4 @@ class PdfSummary(
     """
     
     name: str
-    type: PdfType
+    type: PdfType # See gallagher docs for enum

--- a/gallagher/dto/utils.py
+++ b/gallagher/dto/utils.py
@@ -180,7 +180,7 @@ class AppBaseModel(BaseModel):
 
         https://docs.python.org/3/reference/datamodel.html
         """
-        return f"{self.__class__.__name__}({self.dict()})"
+        return f"{self.__class__.__name__}({self.model_dump()})"
 
 
 class AppBaseResponseModel(AppBaseModel):


### PR DESCRIPTION
Major refactor of the way `personalDataDefinitions` are parsed for the cardholder, refs:
- #1 

Initially I was going down a path of implementing a cache of the personalDataFields which is unnecessary as the cardholder detail response will always return what we need. Hence it makes sense to parse the personalDataDefinitions (see [commit](https://github.com/anomaly/gallagher/commit/1c06118baecfffb3103ff2508bf91f9015c4322a)) and then make the top level keys accessible as aliases.