### PR TITLE
fix: version not being reflected on __init__.py

### DIFF
--- a/gallagher/__init__.py
+++ b/gallagher/__init__.py
@@ -7,4 +7,12 @@
  Distributed under the terms of the MIT License.
 """
 
-__version__ = "0.1.0-alpha.9"
+# Assumed we are running Python 3.8 or later
+# https://docs.python.org/3.8/library/importlib.metadata.html
+from importlib.metadata import version, PackageNotFoundError
+__package_name__ = __name__.split(".", 1)[0]
+
+try:
+    __version__ = version(__package_name__)
+except PackageNotFoundError:
+    __version__ = "0.0.0"  # fallback for local dev

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gallagher"
-version = "0.1.0-alpha.11"
+version = "0.1.0-alpha.12"
 description = "The missing developer toolkit for Gallagher Command Centre"
 authors = ["Dev Mukherjee <devraj@gmail.com>"]
 readme = "README.md"


### PR DESCRIPTION
## 🐛 Fixes
- Automates `__init__.py` getting version metadata from `poetry` package, ensuring that it's always kept up to date when `pyproject.toml` is updated.