### PR TITLE
Alpha 13

### DIFF
--- a/gallagher/dto/detail/cardholder.py
+++ b/gallagher/dto/detail/cardholder.py
@@ -1,5 +1,6 @@
 """ Cardholder Detail """
 from typing import Optional, Any
+from datetime import datetime
 from typing_extensions import Self
 
 from pydantic import model_validator
@@ -17,6 +18,7 @@ from ..ref import (
     DivisionRef,
     PlaceholderRef,
     RoleRef,
+    AccessZoneRef,
 )
 
 from ..summary import (
@@ -93,6 +95,10 @@ class CardholderDetail(
     short_name: Optional[str] = None
     description: Optional[str] = None
     authorised: bool
+
+    last_successful_access_time: Optional[datetime] = None
+    # last_successful_access_zone: Optional[AccessZoneRef] = None
+    server_display_name: Optional[str] = None
 
     disable_cipher_pad: bool = False
     division: DivisionRef

--- a/gallagher/dto/detail/cardholder.py
+++ b/gallagher/dto/detail/cardholder.py
@@ -97,7 +97,7 @@ class CardholderDetail(
     authorised: bool
 
     last_successful_access_time: Optional[datetime] = None
-    # last_successful_access_zone: Optional[AccessZoneRef] = None
+    last_successful_access_zone: Optional[AccessZoneRef] = None
     server_display_name: Optional[str] = None
 
     disable_cipher_pad: bool = False

--- a/gallagher/dto/ref/zone.py
+++ b/gallagher/dto/ref/zone.py
@@ -1,11 +1,15 @@
 from ..utils import (
     AppBaseModel,
-    IdentityMixin,
+    OptionalIdentityMixin,
     HrefMixin,
 )
 
 
-class AccessZoneRef(AppBaseModel, IdentityMixin, HrefMixin):
+class AccessZoneRef(
+    AppBaseModel,
+    OptionalIdentityMixin,
+    HrefMixin
+):
     """AccessZone represents"""
 
     name: str

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,8 +1,0 @@
-""" Tests to see that are running the tests against the right version
-"""
-
-from gallagher import __version__
-
-
-async def test_version():
-    assert __version__ == "0.1.0a12"


### PR DESCRIPTION
## 💅 Improves
- `AccessZoneRef` now has an `Optional`, `Identifier`. `last_successful_access_zone` on `CardholderDetail` does not send back an `Identifier` but all other responses using the `Ref` do, it was wiser to relax this rule.