### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -4,6 +4,9 @@ on:
   push:
     tags:
       - "v*.*.*" # Trigger the workflow only on version tags
+permissions:
+  contents: read
+  packages: write
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/anomaly/gallagher/security/code-scanning/6](https://github.com/anomaly/gallagher/security/code-scanning/6)

To fix the issue, add an explicit `permissions` block to the workflow to assign the minimum required privileges for the `GITHUB_TOKEN`. Since the workflow involves tasks like syncing dependencies, running tests, and publishing a package, the following permissions are needed:

1. `contents: read`: Required to access the repository contents.
2. `packages: write`: Needed to publish the package to PyPI.

The `permissions` block should be added at the workflow level to apply to all jobs. If any job requires different permissions, a job-specific `permissions` block can override the workflow-level permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
