### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -7,6 +7,8 @@ on:
     paths:
       - docs/**
       - .github/workflows/deploy-docs.yml
+permissions:
+  contents: write
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/anomaly/gallagher/security/code-scanning/5](https://github.com/anomaly/gallagher/security/code-scanning/5)

To fix the problem, add an explicit `permissions` block to the workflow to limit the permissions granted to the GITHUB_TOKEN. The optimal location in this case is at the workflow root (above `jobs:`) if all jobs require the same permissions, otherwise, place it inside individual jobs. Since this workflow is for publishing documentation using GitHub Pages, it typically only needs permission to read and write content within the repository. The minimal safe permissions are `contents: write`. If you are certain that only read is needed, you may use `contents: read`, but publishing likely requires write access. Therefore, above the `jobs:` key, insert:

```yaml
permissions:
  contents: write
```

No imports or definitions are involved; this is a declarative YAML change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
